### PR TITLE
Tweak how link blocks render urls

### DIFF
--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -55,41 +55,29 @@ def test_link_block_clean_both_page_and_url():
 
 
 @pytest.mark.django_db
-def test_link_block_to_python_page():
+def test_link_block_get_context_page():
     link = LinkBlock()
-    value = link.to_python({'page': 2})
-    assert value['url'] == "/"
+    ctx = link.get_context({'page': Page.objects.get(pk=2)})
+    assert ctx['url'] == "/"
 
 
-def test_link_block_to_python_absolute_url():
+def test_link_block_get_context_absolute_url():
     link = LinkBlock()
-    value = link.to_python({'absolute_url': 'http://test.com/'})
-    assert value['url'] == "http://test.com/"
+    ctx = link.get_context({'absolute_url': 'http://test.com/'})
+    assert ctx['url'] == "http://test.com/"
 
 
 @pytest.mark.django_db
-def test_link_block_to_python_page_and_absolute_url():
+def test_link_block_get_context_page_and_absolute_url():
     link = LinkBlock()
-    value = link.to_python({'page': 2, 'absolute_url': 'http://test.com/'})
-    assert value['url'] == "/"
-
-
-def test_link_block_to_python_nothing():
-    link = LinkBlock()
-    value = link.to_python({})
-    assert 'url' not in value
+    ctx = link.get_context({'page': Page.objects.get(pk=2), 'absolute_url': 'http://test.com/'})
+    assert ctx['url'] == "/"
 
 
 def test_link_block_get_context_no_url():
     link = LinkBlock()
     ctx = link.get_context({})
-    assert ctx['has_url'] == False
-
-
-def test_link_block_get_context_with_url():
-    link = LinkBlock()
-    ctx = link.get_context({'url': 'some url'})
-    assert ctx['has_url'] == True
+    assert ctx['url'] == None
 
 
 @freeze_time("2017-01-01")

--- a/wagtail_extensions/blocks.py
+++ b/wagtail_extensions/blocks.py
@@ -51,17 +51,15 @@ class LinkBlock(blocks.StructBlock):
 
         return super().clean(value)
 
-    def to_python(self, value):
-        value = super().to_python(value)
-        if value.get('page'):
-            value['url'] = value['page'].url
-        elif value.get('absolute_url'):
-            value['url'] = value.get('absolute_url')
-        return value
-
     def get_context(self, value, parent_context=None):
         ctx = super().get_context(value, parent_context=parent_context)
-        ctx['has_url'] = 'url' in value
+        if value.get('page'):
+            url = value['page'].url
+        elif value.get('absolute_url'):
+            url = value.get('absolute_url')
+        else:
+            url = None
+        ctx['url'] = url
         return ctx
 
 

--- a/wagtail_extensions/templates/wagtail_extensions/blocks/link.html
+++ b/wagtail_extensions/templates/wagtail_extensions/blocks/link.html
@@ -1,9 +1,9 @@
-{% if has_url %}
-    <a href="{{ value.url }}">
+{% if url %}
+    <a href="{{ url }}">
         {% if value.page %}
             {% firstof value.text value.page.title %}
         {% else %}
-            {% firstof value.text value.url %}
+            {% firstof value.text url %}
         {% endif %}
     </a>
 {% endif %}


### PR DESCRIPTION
There is an issue with using `to_python` to store generated values in certain circumstances.