### PR TITLE
Use a custom value class for LinkBlock which provides two helper properties

### DIFF
--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -50,8 +50,9 @@ def test_link_block_with_url():
     value = block.to_python({
         'link': [{'type': 'url', 'value': '/hello/'}]
     })
-    html = block.render(value)
-    assert html.strip() == '<a href="/hello/">/hello/</a>'
+
+    assert value.link_url == '/hello/'
+    assert value.link_text == '/hello/'
 
 
 def test_link_block_with_url_and_text():
@@ -60,8 +61,18 @@ def test_link_block_with_url_and_text():
         'text': 'Hello World',
         'link': [{'type': 'url', 'value': '/hello/'}]
     })
-    html = block.render(value)
-    assert html.strip() == '<a href="/hello/">Hello World</a>'
+    assert value.link_url == '/hello/'
+    assert value.link_text == 'Hello World'
+
+
+def test_link_block_with_empty_string_text():
+    block = LinkBlock()
+    value = block.to_python({
+        'text': '',
+        'link': [{'type': 'url', 'value': '/hello/'}]
+    })
+    assert value.link_url == '/hello/'
+    assert value.link_text == '/hello/'
 
 
 @pytest.mark.django_db
@@ -71,8 +82,8 @@ def test_link_block_with_page(page):
         'link': [{'type': 'page', 'value': page.pk}]
     })
 
-    html = block.render(value)
-    assert html.strip() == '<a href="{}">{}</a>'.format(page.url, page.title)
+    assert value.link_url == page.url
+    assert value.link_text == page.title
 
 
 @pytest.mark.django_db
@@ -82,8 +93,8 @@ def test_link_block_with_page_and_text(page):
         'text': 'Hello World',
         'link': [{'type': 'page', 'value': page.pk}]
     })
-    html = block.render(value)
-    assert html.strip() == '<a href="{}">Hello World</a>'.format(page.url)
+    assert value.link_url == page.url
+    assert value.link_text == 'Hello World'
 
 
 def test_link_block_clean_for_required():

--- a/wagtail_extensions/blocks.py
+++ b/wagtail_extensions/blocks.py
@@ -33,6 +33,31 @@ class StrippedListBlock(blocks.ListBlock):
         ]
 
 
+class LinkBlockStructValue(blocks.StructValue):
+
+    @property
+    def link_url(self):
+        link_item = self['link'][0]
+        if link_item.block_type in ('page', 'document'):
+            return link_item.value.url
+        else:
+            return link_item.value      # raw url
+
+    @property
+    def link_text(self):
+        link_item = self['link'][0]
+        if link_item.block_type in ('page', 'document'):
+            link_text = link_item.value.title
+        else:
+            link_text = link_item.value
+
+        # If text is set then it takes precedence
+        if self.get('text'):
+            link_text = self['text']
+
+        return link_text
+
+
 class LinkBlock(blocks.StructBlock):
 
     text = blocks.CharBlock(required=False)
@@ -56,27 +81,10 @@ class LinkBlock(blocks.StructBlock):
             raise ValidationError('LinkBlock validation error', params=errors)
         return result
 
-    def get_context(self, value, parent_context=None):
-        ctx = super().get_context(value, parent_context=parent_context)
-
-        link_item = value['link'][0]
-        if link_item.block_type in ('page', 'document'):
-            link_url = link_item.value.url
-            link_text = link_item.value.title
-        else:
-            link_url = link_item.value      # raw url
-            link_text = link_item.value
-
-        # If text is set then it takes precedence
-        if value.get('text'):
-            link_text = value['text']
-        ctx['link_url'] = link_url
-        ctx['link_text'] = link_text
-        return ctx
-
 
     class Meta:
         template = 'wagtail_extensions/blocks/link.html'
+        value_class = LinkBlockStructValue
 
 
 class CarouselItemBlock(blocks.StructBlock):

--- a/wagtail_extensions/templates/wagtail_extensions/blocks/link.html
+++ b/wagtail_extensions/templates/wagtail_extensions/blocks/link.html
@@ -1,1 +1,1 @@
-<a href="{{ link_url }}">{{ link_text }}</a>
+<a href="{{ value.link_url }}">{{ value.link_text }}</a>


### PR DESCRIPTION
This is better than using `get_context` because it can be used by any template.