### PR TITLE
Return empty strings for values in LinkBlock if no link exists.

### DIFF
--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -75,6 +75,16 @@ def test_link_block_with_empty_string_text():
     assert value.link_text == '/hello/'
 
 
+def test_link_block_with_missing_streamblock():
+    block = LinkBlock()
+    value = block.to_python({
+        'text': '',
+        'link': []
+    })
+    assert value.link_url == ''
+    assert value.link_text == ''
+
+
 @pytest.mark.django_db
 def test_link_block_with_page(page):
     block = LinkBlock()

--- a/wagtail_extensions/blocks.py
+++ b/wagtail_extensions/blocks.py
@@ -37,7 +37,11 @@ class LinkBlockStructValue(blocks.StructValue):
 
     @property
     def link_url(self):
-        link_item = self['link'][0]
+        try:
+            link_item = self['link'][0]
+        except IndexError:
+            return ''
+
         if link_item.block_type in ('page', 'document'):
             return link_item.value.url
         else:
@@ -45,7 +49,11 @@ class LinkBlockStructValue(blocks.StructValue):
 
     @property
     def link_text(self):
-        link_item = self['link'][0]
+        try:
+            link_item = self['link'][0]
+        except IndexError:
+            return ''
+
         if link_item.block_type in ('page', 'document'):
             link_text = link_item.value.title
         else:


### PR DESCRIPTION
We had assumed that the template would check whether a link exists before trying to render it, which is a risky assumption to make.