### PR TITLE
Add tools for tracking form submissions

### DIFF
--- a/wagtail_extensions/mixins.py
+++ b/wagtail_extensions/mixins.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.db import models
 from django.http import HttpResponseRedirect
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 
 from honeypot.decorators import check_honeypot
@@ -12,6 +13,7 @@ from .models import ContactSubmission
 
 
 class ContactMixin(models.Model):
+
     form_class = ContactForm
     success_url = None
     store_submissions = True
@@ -50,6 +52,8 @@ class ContactMixin(models.Model):
                 success_message = self.get_success_message()
                 if success_message:
                     messages.add_message(request, messages.INFO, success_message)
+
+                request.session['enquiry_form_submitted'] = timezone.now()
                 # Redirect to the current page, to prevent resubmissions
                 return HttpResponseRedirect(self.get_success_url())
 

--- a/wagtail_extensions/templates/wagtail_extensions/partials/track_form_submission.html
+++ b/wagtail_extensions/templates/wagtail_extensions/partials/track_form_submission.html
@@ -1,0 +1,7 @@
+{% if enquiry_form_submitted %}
+<script>
+if(window.gtag){
+    gtag('event', 'submitted', {'event_category': 'enquiry_form'})
+}
+</script>
+{% endif %}

--- a/wagtail_extensions/templatetags/wagtailextensions_tags.py
+++ b/wagtail_extensions/templatetags/wagtailextensions_tags.py
@@ -2,6 +2,7 @@ from urllib.parse import urlsplit
 
 from django.template import Library
 from django.template.defaultfilters import stringfilter
+from django.utils import timezone
 
 import bleach
 from wagtailgeowidget.app_settings import (
@@ -58,3 +59,15 @@ def block_method(block_value, method_name):
         return method(block_value)
     else:
         return None
+
+
+@register.inclusion_tag('wagtail_extensions/partials/track_form_submission.html')
+def track_form_submission(request):
+    submitted = request.session.get('enquiry_form_submitted', False)
+    if submitted:
+        # Remove the session variable
+        del request.session['enquiry_form_submitted']
+        if (timezone.now() - submitted).seconds < 60:
+            return {'enquiry_form_submitted': True}
+
+    return {'enquiry_form_submitted': False}


### PR DESCRIPTION
Track form submissions in the session, and then provide a template tag that checks this session variable and renders GA tracking code appropriately.