### PR TITLE
Fix the data type used to track form submissions in the sessions.

### DIFF
--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -20,7 +20,7 @@ def test_bleanclean_strips():
 def test_track_form_submission(rf):
     request = rf.get('/')
     request.session = {
-        'enquiry_form_submitted': timezone.now()
+        'enquiry_form_submitted': timezone.now().strftime('%Y-%m-%d %H:%M')
     }
 
     ctx = track_form_submission(request)
@@ -33,7 +33,7 @@ def test_track_form_submission_expired(rf):
     request = rf.get('/')
     request.session = {
         # this was submitted too long ago to qualify
-        'enquiry_form_submitted': timezone.now() - timedelta(seconds=3600)
+        'enquiry_form_submitted': (timezone.now() - timedelta(seconds=3600)).strftime('%Y-%m-%d %H:%M')
     }
 
     ctx = track_form_submission(request)
@@ -45,6 +45,18 @@ def test_track_form_submission_expired(rf):
 def test_track_form_submission_no_submission(rf):
     request = rf.get('/')
     request.session = {}
+
+    ctx = track_form_submission(request)
+
+    assert ctx == {'enquiry_form_submitted': False}
+
+
+def test_track_form_invalid_session_data(rf):
+    request = rf.get('/')
+    request.session = {
+        # this was submitted too long ago to qualify
+        'enquiry_form_submitted': 'this is not a valid timestamp'
+    }
 
     ctx = track_form_submission(request)
 

--- a/wagtail_extensions/mixins.py
+++ b/wagtail_extensions/mixins.py
@@ -53,7 +53,7 @@ class ContactMixin(models.Model):
                 if success_message:
                     messages.add_message(request, messages.INFO, success_message)
 
-                request.session['enquiry_form_submitted'] = timezone.now()
+                request.session['enquiry_form_submitted'] = timezone.now().strftime('%Y-%m-%d %H:%M')
                 # Redirect to the current page, to prevent resubmissions
                 return HttpResponseRedirect(self.get_success_url())
 

--- a/wagtail_extensions/templatetags/wagtailextensions_tags.py
+++ b/wagtail_extensions/templatetags/wagtailextensions_tags.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from urllib.parse import urlsplit
 
 from django.template import Library
@@ -67,7 +68,12 @@ def track_form_submission(request):
     if submitted:
         # Remove the session variable
         del request.session['enquiry_form_submitted']
-        if (timezone.now() - submitted).seconds < 60:
+        try:
+            submitted_time = datetime.strptime(submitted, '%Y-%m-%d %H:%M')
+        except ValueError:
+            return {'enquiry_form_submitted': False}
+
+        if (timezone.now() - timezone.make_aware(submitted_time)).seconds < 60:
             return {'enquiry_form_submitted': True}
 
     return {'enquiry_form_submitted': False}


### PR DESCRIPTION
datetimes are not JSON serialisable and will fail with the default session serialiser.