### PR TITLE
Fix an issue with opening times empty state

### DIFF
--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -152,9 +152,9 @@ def test_openingtime_block_clean_valid():
     openingtime.clean({'start': '08:00', 'end': '20:00', 'date': '2017-01-01'})
 
 
-def test_openingtime_block_to_python_no_weekday():
+def test_openingtime_block_to_python_empty():
     openingtime = OpeningTimeBlock()
-    openingtime.to_python({})
+    openingtime.to_python({'label': '', 'date': None, 'closed': False, 'start': None, 'end': None, 'weekday': ''})
     # Pass without error
 
 

--- a/wagtail_extensions/blocks.py
+++ b/wagtail_extensions/blocks.py
@@ -205,11 +205,11 @@ class OpeningTimeBlock(blocks.StructBlock):
     def to_python(self, value):
         value = super().to_python(value)
         weekday = value.get('weekday')
-        if weekday is not None:
+        if weekday is not None and weekday != '':
             value['weekday'] = int(weekday)
 
             label = value.get('label')
-            if value['weekday'] == self.PUBLIC and not label:
+            if value['weekday'] == self.PUBLIC and (label is None or label == ''):
                 value['label'] = self.PUBLIC_LABEL
         return value
 


### PR DESCRIPTION
Our test for the empty to python method wasn't passing what is actually passed by wagtail to the `to_python` method for an incomplete opening time.