### PR TITLE
Fix inverted logic in SiteSingleton.can_create_at

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ test_requires = [
 
 setup(
     name='regulus-wagtail-extensions',
-    version='2.5',
+    version='2.5.1',
     packages=find_packages(),
     include_package_data=True,
     license='MIT License',

--- a/wagtail_extensions/mixins.py
+++ b/wagtail_extensions/mixins.py
@@ -24,7 +24,7 @@ class SiteSingleton:
         site = parent.get_site()
 
         if site:
-            can_create_for_site = site.root_page.get_descendants().type(cls).exists()
+            can_create_for_site = not site.root_page.get_descendants().type(cls).exists()
         return can_create and can_create_for_site
 
 


### PR DESCRIPTION
Original commit inverted the logic that was originally being used whilst improving the performance