### PR TITLE
Refactor maps JS not to require jQuery.

### DIFF
--- a/wagtail_extensions/static/wagtail_extensions/js/maps.js
+++ b/wagtail_extensions/static/wagtail_extensions/js/maps.js
@@ -1,13 +1,10 @@
 "use strict";
 
 function init_maps() {
-    var maps = $('.wagtail-geo-widget-map');
-
-    maps.each(function(idx) {
-        var $map_el = $(this),
-            point = {lat: $map_el.data('lat'), lng: $map_el.data('lng')},
-            map = new google.maps.Map($map_el[0], {
-                zoom: $map_el.data('zoom'),
+    document.querySelectorAll('.wagtail-geo-widget-map').forEach(function(el) {
+        var point = {lat: parseFloat(el.getAttribute('data-lat')), lng: parseFloat(el.getAttribute('data-lng'))},
+            map = new google.maps.Map(el, {
+                zoom: parseInt(el.getAttribute('data-zoom')),
                 center: point
             }),
             marker = new google.maps.Marker({


### PR DESCRIPTION
jQuery is not available in the global context any more on sites that are using webpack. This refactors this JS not to need jQuery at all.