### PR TITLE
Fix rendering of special characters in plain text email body.

### DIFF
--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 from wagtail.core.models import Page
 from wagtail_extensions.templatetags.wagtailextensions_tags import (
-    bleachclean, page_menu_children, track_form_submission, menu)
+    page_menu_children, track_form_submission, menu)
 
 
 @pytest.mark.django_db
@@ -40,18 +40,6 @@ def render_template():
         load_tags_string = '{% load wagtailextensions_tags %}'
         return template_engine.from_string(load_tags_string + template_string).render()
     return func
-
-
-def test_bleanclean_cleandata():
-    cleaned = bleachclean('Hello')
-
-    assert cleaned == 'Hello'
-
-
-def test_bleanclean_strips():
-    cleaned = bleachclean('<script>evil</script>')
-
-    assert cleaned == 'evil'
 
 
 def test_track_form_submission(rf):

--- a/wagtail_extensions/templates/wagtail_extensions/email/message.txt
+++ b/wagtail_extensions/templates/wagtail_extensions/email/message.txt
@@ -1,7 +1,5 @@
-{% load bleachclean from wagtailextensions_tags %}
-
 {% autoescape off %}
 Enquiry from {{ name }} ({{ email }}):
-{% endautoescape %}
 
-{{ message|bleachclean }}
+{{ message|striptags }}
+{% endautoescape %}

--- a/wagtail_extensions/templatetags/wagtailextensions_tags.py
+++ b/wagtail_extensions/templatetags/wagtailextensions_tags.py
@@ -48,11 +48,6 @@ def humanize_date_range(start, end):
     return "{} - {}".format(start.strftime(start_fmt), end.strftime(day_fmt))
 
 
-@register.filter
-def bleachclean(value):
-    return bleach.clean(value, strip=True)
-
-
 @register.simple_tag
 def block_method(block_value, method_name):
     method = getattr(block_value.block, method_name)


### PR DESCRIPTION
We were using `bleach.clean()` here which doesn't make sense because Bleach is intended for HTML environments and it escapes special characters like `"` and `&`. Switching instead to using `striptags` to remove anything obviously dodgy, and not escaping anything else.